### PR TITLE
Remove createJSModules

### DIFF
--- a/android/src/main/java/ca/jaysoo/extradimensions/ExtraDimensionsPackage.java
+++ b/android/src/main/java/ca/jaysoo/extradimensions/ExtraDimensionsPackage.java
@@ -17,11 +17,6 @@ public class ExtraDimensionsPackage implements ReactPackage {
         return Arrays.asList();
     }
 
-    @Override 
-    public List<Class<? extends JavaScriptModule>> createJSModules() { 
-        return Collections.emptyList(); 
-    }
-
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();


### PR DESCRIPTION
ReactPackage no longer defines a createJSModules method that must be overwritten. Since nothing else in the project references this method, we can safely remove it entirely.